### PR TITLE
Add reference to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,5 @@ To contribute a new report, open a pull request. All reports go in the `reports/
 
 Nothing in this repository comes will any explicit or implied warranty. For more imformation see [the license](LICENSE).
 
-
+## Using Reports
+See the Netbox [report documentation](https://netbox.readthedocs.io/en/stable/additional-features/reports/#netbox-reports) for instructions about deploying the reports to your server.


### PR DESCRIPTION
Update README to include reference to report documentation so users can find out how to deploy the reports.