### PR TITLE
Fix method name confusion in ipam-reports/ip-reports

### DIFF
--- a/reports/ipam-reports/ip-reports.py
+++ b/reports/ipam-reports/ip-reports.py
@@ -30,7 +30,7 @@ class DeviceIPReport(Report):
                     if device.primary_ip6_id is not None:
                         self.log_failure(device, "Device has primary IPv4 and IPv6 address but no interfaces")
                     else:
-                        self.log_warn(device, "Device has missing primary IPv4 addresses but no interfaces")
+                        self.log_warning(device, "Device has missing primary IPv4 addresses but no interfaces")
                 else:
                     self.log_success(device)
             elif device.primary_ip4_id is None:


### PR DESCRIPTION
The report has a misspelled call to log_warn (it's log_warning), causing report execution to fail when hitting the case in question. There are no further instances of the same error.