### PR TITLE
ip-check-prefix.py: prefix with is_pool

### DIFF
--- a/reports/ipam-reports/ip-check-prefix.py
+++ b/reports/ipam-reports/ip-check-prefix.py
@@ -26,9 +26,7 @@ class CheckPrefixLength(Report):
                                  (ipaddr.family, a.version))
                 continue
             # We allow loopback-like things to be single address *or* have the parent prefix length
-            if ipaddr.role in LOOPBACK_ROLES and (
-                     (a.version == 4 and a.prefixlen == 32) or
-                     (a.version == 6 and a.prefixlen == 128)):
+            if ipaddr.role in LOOPBACK_ROLES and a.size == 1:
                 self.log_success(ipaddr)
                 continue
             parents = [p for p in prefixes if
@@ -39,9 +37,7 @@ class CheckPrefixLength(Report):
                 continue
             parent = parents[-1]
             # If parent is a pool, allow single address *or* have the parent prefix length
-            if parent.is_pool and (
-                     (a.version == 4 and a.prefixlen == 32) or
-                     (a.version == 6 and a.prefixlen == 128)):
+            if parent.is_pool and a.size == 1:
                 self.log_success(ipaddr)
                 continue
             if a.prefixlen != parent.prefix.prefixlen:

--- a/reports/ipam-reports/ip-check-prefix.py
+++ b/reports/ipam-reports/ip-check-prefix.py
@@ -38,6 +38,12 @@ class CheckPrefixLength(Report):
                 self.log_info(ipaddr, "No parent prefix")
                 continue
             parent = parents[-1]
+            # If parent is a pool, allow single address *or* have the parent prefix length
+            if parent.is_pool and (
+                     (a.version == 4 and a.prefixlen == 32) or
+                     (a.version == 6 and a.prefixlen == 128)):
+                self.log_success(ipaddr)
+                continue
             if a.prefixlen != parent.prefix.prefixlen:
                 self.log_failure(ipaddr, "prefixlen (%d) inconsistent with parent prefix (%s)" %
                                  (a.prefixlen, str(parent.prefix)))


### PR DESCRIPTION
If parent prefix is a pool, allow contained address to be /32 (v4) or /128 (v6)

(Commit rebased on top of #20)