### PR TITLE
Add CheckCableLocality report

### DIFF
--- a/reports/dcim-reports/CheckCableLocality.py
+++ b/reports/dcim-reports/CheckCableLocality.py
@@ -1,0 +1,32 @@
+from extras.reports import Report
+from dcim.models import Cable, RearPort
+from dcim.constants import *
+from circuits.models import CircuitTermination
+
+CABLE_TYPES_OK_BETWEEN_RACKS = {
+    CABLE_TYPE_DAC_PASSIVE,
+}
+
+class CheckCableLocality(Report):
+    description = "Warn on cables between racks, error on cables between sites"
+
+    def test_cable_endpoints(self):
+        for cable in Cable.objects.prefetch_related('termination_a','termination_b').all():
+            if isinstance(cable.termination_a, CircuitTermination) or isinstance(cable.termination_b, CircuitTermination):
+                continue
+            if cable.termination_a.device.site != cable.termination_b.device.site:
+                self.log_failure(cable, "Endpoints in different sites: {} ({}) and {} ({})".format(
+                    cable.termination_a.device, cable.termination_a.device.site,
+                    cable.termination_b.device, cable.termination_b.device.site,
+                ))
+                continue
+            if isinstance(cable.termination_a, RearPort) and isinstance(cable.termination_b, RearPort):
+                self.log_success(cable)
+                continue
+            if cable.termination_a.device.rack != cable.termination_b.device.rack and cable.type not in CABLE_TYPES_OK_BETWEEN_RACKS:
+                self.log_warning(cable, "Endpoints in different racks: {} ({}) and {} ({})".format(
+                    cable.termination_a.device, cable.termination_a.device.rack,
+                    cable.termination_b.device, cable.termination_b.device.rack,
+                ))
+                continue
+            self.log_success(cable)

--- a/reports/dcim-reports/CheckCableLocality.py
+++ b/reports/dcim-reports/CheckCableLocality.py
@@ -1,9 +1,9 @@
 from extras.reports import Report
 from dcim.models import Cable, RearPort
-from dcim.constants import *
+from dcim.choices import CableTypeChoices
 
 CABLE_TYPES_OK_BETWEEN_RACKS = {
-    CABLE_TYPE_DAC_PASSIVE,
+    CableTypeChoices.TYPE_DAC_PASSIVE,
 }
 
 class CheckCableLocality(Report):

--- a/reports/dcim-reports/CheckCableLocality.py
+++ b/reports/dcim-reports/CheckCableLocality.py
@@ -1,7 +1,6 @@
 from extras.reports import Report
 from dcim.models import Cable, RearPort
 from dcim.constants import *
-from circuits.models import CircuitTermination
 
 CABLE_TYPES_OK_BETWEEN_RACKS = {
     CABLE_TYPE_DAC_PASSIVE,
@@ -12,7 +11,7 @@ class CheckCableLocality(Report):
 
     def test_cable_endpoints(self):
         for cable in Cable.objects.prefetch_related('termination_a','termination_b').all():
-            if isinstance(cable.termination_a, CircuitTermination) or isinstance(cable.termination_b, CircuitTermination):
+            if not getattr(cable.termination_a, 'device', None) or not getattr(cable.termination_b, 'device', None):
                 continue
             if cable.termination_a.device.site != cable.termination_b.device.site:
                 self.log_failure(cable, "Endpoints in different sites: {} ({}) and {} ({})".format(


### PR DESCRIPTION
- error if cable endpoints are in different sites
- warning if cable endpoints are in different racks (except for specified types,
  and rearport to rearport connections)
- now works with Netbox 2.7 (only)