### PR TITLE
Fix error when instantiating components

### DIFF
--- a/scripts/add_device_type_components.py
+++ b/scripts/add_device_type_components.py
@@ -41,7 +41,7 @@ class AddDeviceTypeComponents(Script):
                 names = {i.name for i in getattr(device, item).all()}
                 templates = getattr(dt, templateitem).all()
                 items = [
-                    x.instantiate(device)
+                    x.instantiate(device=device)
                     for x in templates
                     if x.name not in names
                 ]


### PR DESCRIPTION
`template.instantiate()` no longer allows 'device' as a positional parameter: it must be a named parameter in **kwargs